### PR TITLE
Representable API change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ cache: bundler
 
 rvm:
   - ruby-head
-  - 2.1.9
-  - jruby-9.0.0.0
-  - rbx-3.0
+  - 2.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ cache: bundler
 rvm:
   - ruby-head
   - 2.2.2
+  - 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache: bundler
 
 rvm:
   - ruby-head
-  - 2.1.2
-  - 2.0.0
-  - 1.9.3
-  - jruby-19mode
-  - rbx-2.2.10
+  - 2.1.9
+  - jruby-9.0.0.0
+  - rbx-3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Next
 ----
 
-* [#21](https://github.com/ruby-grape/grape-roar/pull/21): Fixes serialization issue due to [representable](https://github.com/trailblazer/representable) API change - [@mach-kernel](https://github.com/mach-kernel)
+* [#21](https://github.com/ruby-grape/grape-roar/pull/21): Fixes serialization issue due to [representable](https://github.com/trailblazer/representable) API change - [@mach-kernel](https://github.com/mach-kernel).
 * Your contribution here.
 
 0.3.0 (12/31/2014)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-Next
+0.4.0 (02/16/2017)
 ----
 
-* Your contribution here.
+* [#21](https://github.com/ruby-grape/grape-roar/pull/21): Fixes serialization issue due to [representable](https://github.com/trailblazer/representable) API change. - [@mach-kernel](https://github.com/mach-kernel)
+* Drops support for Ruby < 2.1.0
 
 0.3.0 (12/31/2014)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-0.4.0 (02/16/2017)
+Next
 ----
 
-* [#21](https://github.com/ruby-grape/grape-roar/pull/21): Fixes serialization issue due to [representable](https://github.com/trailblazer/representable) API change. - [@mach-kernel](https://github.com/mach-kernel)
-* Drops support for Ruby < 2.1.0
+* [#21](https://github.com/ruby-grape/grape-roar/pull/21): Fixes serialization issue due to [representable](https://github.com/trailblazer/representable) API change - [@mach-kernel](https://github.com/mach-kernel)
+* Your contribution here.
 
 0.3.0 (12/31/2014)
 ------------------

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rake', '~>10.5.0'
+  gem 'rake', '~> 10.5.0'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rake'
+  gem 'rake', '~>10.5.0'
 end
 
 group :test do

--- a/grape-roar.gemspec
+++ b/grape-roar.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'grape'
   gem.add_dependency 'roar', '~> 1.1.0'
+  gem.required_ruby_version = '>= 2.1.0'
 end

--- a/grape-roar.gemspec
+++ b/grape-roar.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.version       = Grape::Roar::VERSION
 
   gem.add_dependency 'grape'
-  gem.add_dependency 'roar', '>= 1.0'
+  gem.add_dependency 'roar', '~> 1.1.0'
 end

--- a/grape-roar.gemspec
+++ b/grape-roar.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'grape'
   gem.add_dependency 'roar', '~> 1.1.0'
-  gem.required_ruby_version = '>= 2.2.2'
 end

--- a/grape-roar.gemspec
+++ b/grape-roar.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'grape'
   gem.add_dependency 'roar', '~> 1.1.0'
-  gem.required_ruby_version = '>= 2.1.0'
+  gem.required_ruby_version = '>= 2.2.2'
 end

--- a/lib/grape/roar/formatter.rb
+++ b/lib/grape/roar/formatter.rb
@@ -3,7 +3,7 @@ module Grape
     module Roar
       class << self
         def call(object, env)
-          object.respond_to?(:to_json) ? object.to_json(env: env) : MultiJson.dump(object)
+          object.respond_to?(:to_json) ? object.to_json(user_options: { env: env }) : MultiJson.dump(object)
         end
       end
     end

--- a/lib/grape/roar/version.rb
+++ b/lib/grape/roar/version.rb
@@ -1,5 +1,5 @@
 module Grape
   module Roar
-    VERSION = '0.3.1'
+    VERSION = '0.4.0'
   end
 end

--- a/spec/support/article.rb
+++ b/spec/support/article.rb
@@ -2,6 +2,7 @@ require 'support/article_representer'
 
 class Article
   include Roar::JSON
+  include Roar::Hypermedia
   include ArticleRepresenter
 
   attr_accessor :title, :id

--- a/spec/support/order.rb
+++ b/spec/support/order.rb
@@ -2,6 +2,7 @@ require 'support/order_representer'
 
 class Order
   include Roar::JSON
+  include Roar::Hypermedia
   include OrderRepresenter
 
   attr_accessor :id, :client_id, :articles


### PR DESCRIPTION
Hi there,

Just tracked down a pretty tricky bug; it seems that [representable changed their API](http://trailblazer.to/gems/representable/upgrading-guide.html#to-30) for passing in options into `#to_json`. In short, this would cause the `opts` argument to blocks in the `link(:sym, &block)` DSL to be `nil`.

There probably isn't a good way to prevent this from happening again due to API changes since `roar` brings the dependency in, so I just added a pessimistic constraint against the current latest version. 

Thanks, and please merge as soon as is convenient! :unicorn: 