### PR TITLE
Fix dangerous represent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next
 ----
 
 * Your contribution here.
+* [#23](https://github.com/ruby-grape/grape-roar/pull/23): Resolves pollution issue with invoking representers on singletons ([#16](https://github.com/ruby-grape/grape-roar/issues/16)). - [@mach-kernel](https://github.com/mach-kernel).
 
 
 0.4.1 (07/14/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Next
 ----
 
 * Your contribution here.
-* [#23](https://github.com/ruby-grape/grape-roar/pull/23): Resolves pollution issue with invoking representers on singletons ([#16](https://github.com/ruby-grape/grape-roar/issues/16)). - [@mach-kernel](https://github.com/mach-kernel).
+* [#23](https://github.com/ruby-grape/grape-roar/pull/23): Resolves pollution issue with invoking representers on singletons ([#16](https://github.com/ruby-grape/grape-roar/issues/16)) - [@mach-kernel](https://github.com/mach-kernel).
 
 
 0.4.1 (07/14/2017)

--- a/lib/grape/roar/representer.rb
+++ b/lib/grape/roar/representer.rb
@@ -9,7 +9,11 @@ module Grape
 
       module ClassMethods
         def represent(object, _options = {})
-          object.extend self
+          object.extend(self) unless object.singleton_class == object.class
+        rescue TypeError => e
+          # What do we do here?
+          puts "Grape/Roar: Could not represent a(n) #{object.class.name}: #{e}"
+        ensure
           object
         end
       end

--- a/lib/grape/roar/representer.rb
+++ b/lib/grape/roar/representer.rb
@@ -9,6 +9,7 @@ module Grape
 
       module ClassMethods
         def represent(object, _options = {})
+          # See https://github.com/ruby-grape/grape-roar/issues/16
           raise TypeError if object.singleton_class == object.class
           object.extend(self)
           object

--- a/lib/grape/roar/representer.rb
+++ b/lib/grape/roar/representer.rb
@@ -9,11 +9,8 @@ module Grape
 
       module ClassMethods
         def represent(object, _options = {})
-          object.extend(self) unless object.singleton_class == object.class
-        rescue TypeError => e
-          # What do we do here?
-          puts "Grape/Roar: Could not represent a(n) #{object.class.name}: #{e}"
-        ensure
+          raise TypeError if object.singleton_class == object.class
+          object.extend(self)
           object
         end
       end

--- a/spec/representer_spec.rb
+++ b/spec/representer_spec.rb
@@ -1,20 +1,50 @@
 # frozen_string_literal: true
 
-
+require 'pry'
 
 describe Grape::Roar do
   include_context 'Grape API App'
 
   context 'representer' do
-    before do
-      subject.get('/article/:id') do
-        Article.new(title: 'Lonestar', id: params[:id])
+    context 'with a known model' do
+      before do
+        subject.get('/article/:id') do
+          Article.new(title: 'Lonestar', id: params[:id])
+        end
+      end
+
+      it 'returns a hypermedia representation' do
+        get '/article/666'
+        expect(last_response.body).to eq '{"title":"Lonestar","id":"666","links":[{"rel":"self","href":"/article/666"}]}'
       end
     end
 
-    it 'returns a hypermedia representation' do
-      get '/article/666'
-      expect(last_response.body).to eq '{"title":"Lonestar","id":"666","links":[{"rel":"self","href":"/article/666"}]}'
+    context 'without an instance singleton' do 
+      context 'as nil' do 
+        before do 
+          subject.get('/article/:id') do
+            present(nil, with: ArticleRepresenter)
+          end
+        end
+
+        it 'returns null' do
+          get '/article/666'
+          expect(last_response.body).to eq('null')
+        end
+      end
+
+      context 'as another immediate value' do 
+        before do 
+          subject.get('/article/:id') do
+            present(5, with: ArticleRepresenter)
+          end
+        end
+
+        it 'returns null' do
+          get '/article/666'
+          expect(last_response.body).to eq('null')
+        end
+      end 
     end
   end
 end

--- a/spec/representer_spec.rb
+++ b/spec/representer_spec.rb
@@ -25,9 +25,8 @@ describe Grape::Roar do
           end
         end
 
-        it 'returns null' do
-          get '/article/666'
-          expect(last_response.body).to eq('null')
+        it 'raises TypeError' do
+          expect { get '/article/666' }.to raise_error(TypeError)
         end
       end
 
@@ -38,9 +37,8 @@ describe Grape::Roar do
           end
         end
 
-        it 'returns null' do
-          get '/article/666'
-          expect(last_response.body).to eq('null')
+        it 'raises TypeError' do
+          expect { get '/article/666' }.to raise_error(TypeError)
         end
       end 
     end

--- a/spec/representer_spec.rb
+++ b/spec/representer_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
-
 describe Grape::Roar do
   include_context 'Grape API App'
 

--- a/spec/support/all/article_representer.rb
+++ b/spec/support/all/article_representer.rb
@@ -3,6 +3,7 @@
 module ArticleRepresenter
   include Roar::JSON
   include Roar::Hypermedia
+  include Grape::Roar::Representer
 
   property :title
   property :id


### PR DESCRIPTION
This as a first pass should fix the issues with `nil` and other similar immediate values. 

The bigger issue I am trying to figure out is how to elegantly deal with someone passing a `Class` instance in (i.e. don't decorate `Hash` or similar) -- attempting to do something like `object.singleton_class.extend(self)` does not work. Still digging through code of `representable` for that. 