### PR TITLE
Upgrade to the latest rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,7 +34,7 @@ Style/Documentation:
 # Offense count: 1
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
 # AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
-Style/FileName:
+Naming/FileName:
   Exclude:
     - 'lib/grape-roar.rb'
 
@@ -43,7 +43,7 @@ Style/FileName:
 # NamePrefix: is_, has_, have_
 # NamePrefixBlacklist: is_, has_, have_
 # NameWhitelist: is_a?
-Style/PredicateName:
+Naming/PredicateName:
   Exclude:
     - 'spec/**/*'
     - 'lib/grape/roar/extensions/relations/validations/active_record.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ end
 group :development, :test do
   gem 'nokogiri', '1.6.3.1'
   gem 'rake', '~> 10.5.0'
-  gem 'rubocop', '0.49.1'
+  gem 'rubocop'
 end

--- a/gemfiles/with_activerecord.gemfile
+++ b/gemfiles/with_activerecord.gemfile
@@ -16,7 +16,7 @@ end
 group :development, :test do
   gem "nokogiri", "1.6.3.1"
   gem "rake", "~> 10.5.0"
-  gem "rubocop", "0.49.1"
+  gem "rubocop"
 end
 
 gemspec path: "../"

--- a/gemfiles/with_mongoid.gemfile
+++ b/gemfiles/with_mongoid.gemfile
@@ -16,7 +16,7 @@ end
 group :development, :test do
   gem "nokogiri", "1.6.3.1"
   gem "rake", "~> 10.5.0"
-  gem "rubocop", "0.49.1"
+  gem "rubocop"
 end
 
 gemspec path: "../"

--- a/grape-roar.gemspec
+++ b/grape-roar.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 
 require File.expand_path('../lib/grape/roar/version', __FILE__)

--- a/lib/grape/roar/extensions/relations/adapters/base.rb
+++ b/lib/grape/roar/extensions/relations/adapters/base.rb
@@ -7,11 +7,13 @@ module Grape
         module Adapters
           class Base
             class << self
+              # rubocop:disable Lint/RescueWithoutErrorClass
               def valid_for?(klass)
                 valid_proc.call(klass)
               rescue
                 false
               end
+              # rubocop:enable Lint/RescueWithoutErrorClass
 
               def valid_for(&block)
                 @valid_proc = block

--- a/lib/grape/roar/extensions/relations/validations/mongoid.rb
+++ b/lib/grape/roar/extensions/relations/validations/mongoid.rb
@@ -41,7 +41,7 @@ module Grape
               )
             end
 
-            # rubocop:disable Style/PredicateName
+            # rubocop:disable Naming/PredicateName
             def has_many_valid?(relation)
               relation = klass.reflect_on_association(relation)
 
@@ -52,9 +52,9 @@ module Grape
                 ::Mongoid::Relations::Referenced::Many, relation[:relation]
               )
             end
-            # rubocop:enable Style/PredicateName
+            # rubocop:enable Naming/PredicateName
 
-            # rubocop:disable Style/PredicateName
+            # rubocop:disable Naming/PredicateName
             def has_and_belongs_to_many_valid?(relation)
               relation = klass.reflect_on_association(relation)
 
@@ -66,9 +66,9 @@ module Grape
                 relation[:relation]
               )
             end
-            # rubocop:enable Style/PredicateName
+            # rubocop:enable Naming/PredicateName
 
-            # rubocop:disable Style/PredicateName
+            # rubocop:disable Naming/PredicateName
             def has_one_valid?(relation)
               relation = klass.reflect_on_association(relation)
 
@@ -79,7 +79,7 @@ module Grape
                 ::Mongoid::Relations::Referenced::One, relation[:relation]
               )
             end
-            # rubocop:enable Style/PredicateName
+            # rubocop:enable Naming/PredicateName
           end
         end
       end


### PR DESCRIPTION
 * Renamed `Style/FileName` to `Naming/FileName` to suppress `Style/FileName has the wrong namespace - should be Naming`
 * Renamed `Style/PredicateName` to `Naming/PredicateName` to suppress `Style/PredicateName has the wrong namespace - should be Naming`
 * Magic comment for string encoding is no longer necessary
 * Disabled `Lint/RescueWithoutErrorClass` for `lib/grape/roar/extensions/relations/adapters/base.rb` where standard errors are intentionally rescued