### PR TITLE
Relax dependency constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'appraisal', '2.2.0'
+  gem 'appraisal', '~> 2.2.0'
 end
 
 group :test do
@@ -14,7 +14,7 @@ group :test do
 end
 
 group :development, :test do
-  gem 'nokogiri', '1.6.3.1'
-  gem 'rake', '~> 10.5.0'
+  gem 'nokogiri'
+  gem 'rake'
   gem 'rubocop', '0.49.1'
 end

--- a/gemfiles/with_activerecord.gemfile
+++ b/gemfiles/with_activerecord.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", ">= 4.0.0", require: "active_record"
 
 group :development do
-  gem "appraisal", "2.2.0"
+  gem "appraisal", "~> 2.2.0"
 end
 
 group :test do
@@ -14,8 +14,8 @@ group :test do
 end
 
 group :development, :test do
-  gem "nokogiri", "1.6.3.1"
-  gem "rake", "~> 10.5.0"
+  gem "nokogiri"
+  gem "rake"
   gem "rubocop", "0.49.1"
 end
 

--- a/gemfiles/with_mongoid.gemfile
+++ b/gemfiles/with_mongoid.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "mongoid", ">= 5.0.0", require: "mongoid"
 
 group :development do
-  gem "appraisal", "2.2.0"
+  gem "appraisal", "~> 2.2.0"
 end
 
 group :test do
@@ -14,8 +14,8 @@ group :test do
 end
 
 group :development, :test do
-  gem "nokogiri", "1.6.3.1"
-  gem "rake", "~> 10.5.0"
+  gem "nokogiri"
+  gem "rake"
   gem "rubocop", "0.49.1"
 end
 


### PR DESCRIPTION
The dependency versions seem quite old and we should be using more recent versions. There is also another PR #25 for upgrading to the latest rubocop.