### PR TITLE
Migrate Danger to use danger-pr-comment workflow

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -1,0 +1,11 @@
+name: Danger Comment
+
+on:
+  workflow_run:
+    workflows: [Danger]
+    types: [completed]
+
+jobs:
+  comment:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
+    secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,22 +1,13 @@
-name: danger
-on: pull_request
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
 jobs:
   danger:
-    name: Dangerfile
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.danger
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4'
-          bundler-cache: true
-      - run: |
-          # the token is public, has public_repo scope and belongs to the grape-bot user owned by @dblock, this is ok
-          TOKEN=$(echo -n Z2hwX2lYb0dPNXNyejYzOFJyaTV3QUxUdkNiS1dtblFwZTFuRXpmMwo= | base64 --decode)
-          DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
+    secrets: inherit
+    with:
+      ruby-version: '3.4'
+      bundler-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.5.1 (Next)
 
+* [#35](https://github.com/ruby-grape/grape-roar/pull/35): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.5.0 (2025/09/25)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
-danger.import_dangerfile(gem: 'ruby-grape-danger')
+danger.import_dangerfile(gem: 'danger-pr-comment')
+changelog.check!
 toc.check!

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ end
 group :development, :test do
   gem 'base64'
   gem 'bigdecimal'
+  gem 'danger'
+  gem 'danger-changelog'
+  gem 'danger-pr-comment'
+  gem 'danger-toc'
   gem 'mutex_m'
   gem 'nokogiri'
   gem 'ostruct'

--- a/Gemfile.danger
+++ b/Gemfile.danger
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-group :test do
-  gem 'danger-toc', '~> 0.2.0', require: false
-  gem 'ruby-grape-danger', '~> 0.2.1', require: false
-end


### PR DESCRIPTION
## Summary
- Migrated Danger setup to use `danger-pr-comment` reusable workflow from numbata/danger-pr-comment
- Added danger-pr-comment, danger-changelog, danger-toc, and danger gems to main Gemfile
- Updated Dangerfile to import danger-pr-comment and add changelog.check!
- Created new danger-comment.yml workflow to post PR comments
- Removed Gemfile.danger in favor of using the main Gemfile

## Changes
- Updated `.github/workflows/danger.yml` to use reusable workflow pattern
- Created `.github/workflows/danger-comment.yml` for posting Danger comments on PRs
- Updated `Dangerfile` to use danger-pr-comment and add changelog validation
- Added Danger-related gems to main `Gemfile`
- Removed `Gemfile.danger`

This follows the same pattern used in slack-ruby/slack-ruby-client#581 and slack-ruby/slack-ruby-bot-server#181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)